### PR TITLE
Add setting to restore all variables from cache

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -90,6 +90,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Cache Key List
+    |--------------------------------------------------------------------------
+    |
+    | Defines a cache key where the entire list of secret names should be cached.
+    | When set, this will cause ALL values retreived from AWS to be cached and
+    | restored to environment variables, even if they are not in the config.
+    |
+    | If this is not set, only the items in variables-config will be restored
+    | from the cache.
+    |
+    */
+
+    'cache-key-list' => '',
+
+    /*
+    |--------------------------------------------------------------------------
     | Debugging
     |--------------------------------------------------------------------------
     |

--- a/tests/LaravelAwsSecrestsManagerCacheAllTest.php
+++ b/tests/LaravelAwsSecrestsManagerCacheAllTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tapp\LaravelAwsSecretsManager\Tests;
+
+use Aws\SecretsManager\SecretsManagerClient;
+use Illuminate\Support\Facades\Cache;
+use Orchestra\Testbench\TestCase;
+use Tapp\LaravelAwsSecretsManager\LaravelAwsSecretsManager;
+
+/**
+ * 
+ */
+class LaravelAwsSecretsManagerCacheAllTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.env', 'dev');
+        $app['config']->set('aws-secrets-manager.enabled-environments', ['dev']);
+        $app['config']->set('aws-secrets-manager.variables-config', []);
+        $app['config']->set('aws-secrets-manager.cache-expiry', 1);
+        $app['config']->set('aws-secrets-manager.cache-key-list', 'aws-all');
+	}
+
+    /**
+     * @test
+     */
+    public function loadSecrets_sets_all_variables_in_cache()
+    {
+        $secretList = [
+            'SecretList' => [
+                [
+                    'ARN' => 'test1',
+                    'SecretString' => json_encode([
+                        'name' => 'FIRST_VAR',
+                        'value' => 'var1',
+                    ]),
+                ],
+                [
+                    'ARN' => 'test2',
+                    'SecretString' => json_encode([
+                        'name' => 'SECOND_VAR',
+                        'value' => 'var2',
+                    ]),
+                ],
+            ],
+        ];
+
+        $mock = Cache::shouldReceive('store')->andReturnSelf();
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldReceive('put')->with('FIRST_VAR', 'var1', 60);
+        $mock->shouldReceive('put')->with('SECOND_VAR', 'var2', 60);
+        $mock->shouldReceive('put')->with('aws-all', ['FIRST_VAR', 'SECOND_VAR'], 60);
+
+        $secrestManager = $this->getTestableAwsSecretsManager($secretList);
+        $secrestManager->loadSecrets();
+
+        $this->assertEquals('var1', getenv('FIRST_VAR'));
+        $this->assertEquals('var2', getenv('SECOND_VAR'));
+    }
+
+    /**
+     * @test
+     */
+    public function loadSecrets_sets_all_variables_in_cache_when_using_array()
+    {
+        $secretList = [
+            'SecretList' => [
+                [
+                    'ARN' => 'test1',
+                    'SecretString' => json_encode([
+                        'FIRST_VAR' => 'var1a',
+                        'SECOND_VAR' => 'var2a',
+                    ]),
+                ],
+            ],
+        ];
+
+        $mock = Cache::shouldReceive('store')->andReturnSelf();
+        $mock->shouldReceive('get')->andReturn(null);
+        $mock->shouldReceive('put')->with('FIRST_VAR', 'var1a', 60);
+        $mock->shouldReceive('put')->with('SECOND_VAR', 'var2a', 60);
+        $mock->shouldReceive('put')->with('aws-all', ['FIRST_VAR', 'SECOND_VAR'], 60);
+
+        $secrestManager = $this->getTestableAwsSecretsManager($secretList);
+        $secrestManager->loadSecrets();
+
+        $this->assertEquals('var1a', getenv('FIRST_VAR'));
+        $this->assertEquals('var2a', getenv('SECOND_VAR'));
+    }
+
+    /**
+     * @test
+     */
+    public function loadSecrets_restores_all_variables_from_cache()
+    {
+        $mock = Cache::shouldReceive('store')->andReturnSelf();
+        $mock->shouldReceive('get')->with('aws-all')->andReturn(['THIRD_VAR', 'FOURTH_VAR']);
+        $mock->shouldReceive('get')->with('THIRD_VAR')->andReturn('var3');
+        $mock->shouldReceive('get')->with('FOURTH_VAR')->andReturn('var4');
+
+        $secrestManager = $this->getTestableAwsSecretsManager(['SecretList' => []]);
+        $secrestManager->loadSecrets();
+
+        $this->assertEquals('var3', getenv('THIRD_VAR'));
+        $this->assertEquals('var4', getenv('FOURTH_VAR'));
+    }
+
+    /**
+     * Extend the secrets manager so we can mock the AWS client
+     */
+    private function getTestableAwsSecretsManager($secretList = [])
+    {
+        $client = $this->getMockSecretsManagerClient($secretList);
+
+        return new class ($client) extends LaravelAwsSecretsManager {
+            protected $client;
+
+            public function __construct($client)
+            {
+                $this->client = $client;
+                parent::__construct();
+            }
+
+            protected function getSecretsManagerClient()
+            {
+                return $this->client;
+            }
+        };
+    }
+
+    private function getMockSecretsManagerClient($secretList = [])
+    {
+        return new class ($secretList) extends SecretsManagerClient {
+            private $secretList = [];
+
+            public function __construct($secretList)
+            {
+                $this->secretList = $secretList;
+            }
+
+            public function listSecrets($request)
+            {
+                return $this->secretList;
+            }
+
+            public function getSecretValue($request)
+            {
+                $id = $request['SecretId'];
+                foreach ($this->secretList['SecretList'] as $key => $value) {
+                    if ($value['ARN'] == $id) {
+                        return $value;
+                    }
+                }
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
We're already caching everything that comes back from AWS.  However, we only restore things to the environment if they're in the `variables-config`.

This adds the ability to restore things from cache that are not in the config.  It stores the list of variables we get back from AWS in a cache key and then sets all of those in environment variables when we load the cache.  This allows us to add secrets to AWS Secrets Manager and have them referenced as environment variables directly in the code without having to update any code.

Note that environment variables that are stored in the config will probably still need to have an entry in `variables-config`.  They are dependent on the order in which Laravel initializes things, and we can't count on laravel-aws-secrets-manager running before the config is initially created.